### PR TITLE
Install gems for puppet before running it

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -129,8 +129,13 @@ data "cloudinit_config" "config" {
                 start_service : false,
               }
               runcmd : concat(
-                var.pre_runcmd,
                 local.pre_puppet_cmd,
+                [
+                  "/opt/puppetlabs/puppet/bin/gem install json",
+                  "/opt/puppetlabs/puppet/bin/gem install aws-sdk-core",
+                  "/opt/puppetlabs/puppet/bin/gem install aws-sdk-secretsmanager",
+                ]
+                var.pre_runcmd,
                 [
                   join(
                     " ",


### PR DESCRIPTION
puppet cannot initialize if needs aws_get_secret. Dependencies
aws-sdk-core and aws-sdk-secretsmanager are not installed at that point
and the whole thing fails.
