### PR TITLE
Add make package

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -116,6 +116,7 @@ data "cloudinit_config" "config" {
               }
               packages : concat(
                 [
+                  "make",
                   "puppet-code",
                   "infrahouse-toolkit"
                 ],


### PR DESCRIPTION
json gem wants to run `make`

```
[   72.773637] cloud-init[1576]: 17:40:26 +0000 INFO: Version parameter not defined and agent detected. Nothing to do.
[   80.485291] cloud-init[1576]: Building native extensions. This could take a while...
[   80.659106] cloud-init[1576]: ERROR:  Error installing json:
[   80.659686] cloud-init[1576]:        ERROR: Failed to build gem native extension.
[   80.659780] cloud-init[1576]:     current directory: /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/json-2.7.2/ext/json/ext/generator
[   80.659990] cloud-init[1576]: /opt/puppetlabs/puppet/bin/ruby extconf.rb
[   80.660123] cloud-init[1576]: creating Makefile
[   80.660206] cloud-init[1576]: current directory: /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/json-2.7.2/ext/json/ext/generator
[   80.660315] cloud-init[1576]: make DESTDIR\= sitearchdir\=./.gem.20240620-2549-rbri7i sitelibdir\=./.gem.20240620-2549-rbri7i clean
[   80.660393] cloud-init[1576]: current directory: /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/json-2.7.2/ext/json/ext/generator
[   80.660460] cloud-init[1576]: make DESTDIR\= sitearchdir\=./.gem.20240620-2549-rbri7i sitelibdir\=./.gem.20240620-2549-rbri7i
[   80.660532] cloud-init[1576]: make failedNo such file or directory - make
[   80.660704] cloud-init[1576]: Gem files will remain installed in /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/json-2.7.2 for inspection.
[   80.660782] cloud-init[1576]: Results logged to /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/extensions/x86_64-linux/3.2.0/json-2.7.2/gem_make.out
```
