### PR TITLE
fix: mask apt-daily and unattended-upgrades in bootcmd (#87)

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -1,6 +1,16 @@
 locals {
   external_facts_dir    = "/etc/puppetlabs/facter/facts.d"
   bootstrap_script_path = "/usr/local/bin/ih-bootstrap"
+
+  # systemd units that race with cloud-init / Puppet for the dpkg lock on
+  # fresh Ubuntu instances. Stopped and masked in bootcmd; see issue #87.
+  apt_daily_units = [
+    "apt-daily.service",
+    "apt-daily.timer",
+    "apt-daily-upgrade.service",
+    "apt-daily-upgrade.timer",
+    "unattended-upgrades.service",
+  ]
 }
 
 data "aws_region" "current" {}
@@ -78,6 +88,22 @@ data "cloudinit_config" "config" {
             length(var.mounts) > 0 ? { mounts : var.mounts } : {},
             {
               bootcmd : [
+                # Stop and mask apt-daily / unattended-upgrades before anything else
+                # touches apt. These timers race with cloud-init's package install and
+                # any apt-get run from bootcmd / pre_runcmd / Puppet for the dpkg lock;
+                # lost races on noble have been observed to ABANDON instances via the
+                # lifecycle_hook_name ERR trap (see issue #87).
+                #
+                # Puppet owns package state on InfraHouse-managed instances, so we don't
+                # need unattended-upgrades; security patches land via AMI rebuilds +
+                # ASG cycling, not ad-hoc 1 AM service restarts on live nodes.
+                #
+                # `mask` (not `disable`) is required: on noble these units are masked by
+                # default and `disable` is a no-op, so we must mask to keep them from
+                # coming back after a reboot on long-lived instances.
+                "systemctl stop ${join(" ", local.apt_daily_units)} 2>/dev/null || true",
+                "systemctl mask ${join(" ", local.apt_daily_units)}",
+
                 # Create auth inputs for APT repos
                 "echo '${base64encode(local.repo_pairs_json)}' > /var/tmp/apt-auth.json.b64",
                 "base64 -d /var/tmp/apt-auth.json.b64 > /var/tmp/apt-auth.json",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,16 @@ during instance first boot.
 
 Runs early in boot, before package installation. This phase:
 
+- **Stops and masks `apt-daily` / `unattended-upgrades`** - These systemd
+  units race cloud-init for the dpkg lock and have been observed to
+  ABANDON instances on noble when `lifecycle_hook_name` is set (see
+  [issue #87](https://github.com/infrahouse/terraform-aws-cloud-init/issues/87)).
+  Puppet owns package state on InfraHouse-managed instances, so
+  unattended-upgrades is redundant; security patches land via AMI
+  rebuilds + ASG cycling, not ad-hoc restarts on live nodes. `mask`
+  (not `disable`) is used because these units are masked by default on
+  noble and `disable` is a no-op.
+
 - **Sets up APT authentication** - If `authFrom` is configured, runs a Python script
   (`generate_apt_auth.py`) that fetches credentials from AWS Secrets Manager using `boto3`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,16 @@
 A Terraform module that generates cloud-init userdata for EC2 instances in a
 Puppet-managed infrastructure.
 
+![Cloud-Init Bootstrap Flow](assets/architecture.png)
+
 ## Overview
 
 This module bridges the gap between AWS instance launch and Puppet configuration by handling
 essential bootstrapping tasks that must occur before Puppet can take control. It generates a
 complete cloud-init configuration that can be used in AWS launch templates or instance
 configurations.
+
+See [Architecture](architecture.md) for a walk-through of each phase in the diagram.
 
 ## Features
 
@@ -29,6 +33,9 @@ configurations.
 - **ASG Lifecycle Integration** - Optional `lifecycle_hook_name` signals
   `CONTINUE` on success and `ABANDON` on bootstrap failure, preventing
   broken instances from joining the fleet
+- **dpkg Lock Protection** - `apt-daily` timers and
+  `unattended-upgrades` are stopped and masked in `bootcmd`, so they
+  cannot race cloud-init or Puppet for the dpkg lock on first boot
 - **Gzip Compression** - Optional userdata compression for large configurations
 
 ## Quick Start

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -162,6 +162,33 @@ sudo cat /var/log/cloud-init-output.log | grep -i secret
 2. **IAM permissions** - Instance role needs `secretsmanager:GetSecretValue`
 3. **Secret format** - Must be JSON: `{"apt": "username:password"}`
 
+### dpkg lock held / instances ABANDONed ~2 min after launch
+
+**Symptoms:** On fresh noble instances, cloud-init's `apt-get install`
+fails with `Could not get lock /var/lib/dpkg/lock-frontend`, or an ASG
+with `lifecycle_hook_name` set tears the instance down ~2 minutes after
+launch with no useful log artifacts (EBS volume dies with the instance
+before the cloudwatch agent starts).
+
+**Cause:** `unattended-upgrades` and the `apt-daily*` systemd timers run
+on first boot and compete with cloud-init's package install for the
+dpkg/apt lock. Fixed in this module: since the fix for
+[issue #87](https://github.com/infrahouse/terraform-aws-cloud-init/issues/87),
+`bootcmd` stops and masks these units before any other apt step runs.
+
+**Verification:**
+
+```bash
+systemctl is-enabled \
+  apt-daily.service apt-daily.timer \
+  apt-daily-upgrade.service apt-daily-upgrade.timer \
+  unattended-upgrades.service
+# Expected: all five report "masked"
+```
+
+If any report `enabled`, the module version predates the fix — upgrade
+to a version that includes it.
+
 ### Package installation failed
 
 **Symptoms:** Packages from `var.packages` not installed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,12 @@ theme:
 
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - Architecture: architecture.md
+  - Examples: examples.md
+  - Troubleshooting: troubleshooting.md
+  - Changelog: changelog.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/tests/test_apt_source.py
+++ b/tests/test_apt_source.py
@@ -69,11 +69,18 @@ def test_module(aws_provider_version, keep_after):
         print(userdata)
         ud_obj = parse_userdata(tf_output)
         print(json.dumps(ud_obj, indent=4))
-        # Verify a string in this command
-        # "echo 'W3siYXV0aEZyb20iOiJiYXItc2VjcmV0LWFybiIsIm1hY2hpbmUiOiJiYXIifV0=' > /var/tmp/apt-auth.json.b64",
-        assert json.loads(
-            b64decode(ud_obj["bootcmd"][0].split()[1].strip("'")).decode()
-        ) == [{"machine": "bar", "authFrom": "bar-secret-arn"}]
+        # Find the apt-auth.json.b64 echo line (its position in bootcmd is not
+        # fixed — other bootcmd entries like the apt-daily mask run first).
+        # Expected shape:
+        # "echo 'W3siYXV0aEZyb20iOiJiYXItc2VjcmV0LWFybiIsIm1hY2hpbmUiOiJiYXIifV0=' > /var/tmp/apt-auth.json.b64"
+        apt_auth_cmd = next(
+            cmd
+            for cmd in ud_obj["bootcmd"]
+            if isinstance(cmd, str) and cmd.endswith("/var/tmp/apt-auth.json.b64")
+        )
+        assert json.loads(b64decode(apt_auth_cmd.split()[1].strip("'")).decode()) == [
+            {"machine": "bar", "authFrom": "bar-secret-arn"}
+        ]
 
 
 @pytest.mark.parametrize("aws_provider_version", ["~> 6.0"])

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -199,3 +199,23 @@ def test_module(
             assert (
                 pkg not in packages
             ), f"unexpected mount client package '{pkg}' in packages: {packages}"
+
+        # apt-daily / unattended-upgrades must be stopped and masked before any
+        # apt-touching step runs, so they cannot race for the dpkg lock
+        # (see issue #87).
+        bootcmd = ud_obj["bootcmd"]
+        assert bootcmd[0].startswith(
+            "systemctl stop apt-daily"
+        ), f"expected bootcmd to start with systemctl stop of apt-daily units, got: {bootcmd[0]}"
+        assert bootcmd[1].startswith(
+            "systemctl mask apt-daily"
+        ), f"expected bootcmd[1] to mask apt-daily units, got: {bootcmd[1]}"
+        for unit in (
+            "apt-daily.service",
+            "apt-daily.timer",
+            "apt-daily-upgrade.service",
+            "apt-daily-upgrade.timer",
+            "unattended-upgrades.service",
+        ):
+            assert unit in bootcmd[0], f"{unit} missing from stop command: {bootcmd[0]}"
+            assert unit in bootcmd[1], f"{unit} missing from mask command: {bootcmd[1]}"


### PR DESCRIPTION
## Summary

- Stop and mask `apt-daily.{service,timer}`, `apt-daily-upgrade.{service,timer}`, and `unattended-upgrades.service` as the first `bootcmd` steps. Fixes the dpkg-lock race that has been ABANDONing instances ~2 min after launch on noble when `lifecycle_hook_name` is set (#87).
- Rationale: Puppet owns package state on InfraHouse-managed instances, security patches land via AMI rebuilds + ASG cycling, and unsupervised 1 AM service restarts from `unattended-upgrades` are a net negative for stateful services (e.g. Elasticsearch).
- Fix docs site: `mkdocs.yml` nav now lists every page (previously only `Home`, so the sidebar was hidden), and `docs/index.md` shows the architecture diagram up front.

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] `tests/test_module.py` extended: rendered `bootcmd` starts with the stop + mask commands and contains all five unit names
- [ ] `make test-clean` on a real noble instance: `systemctl is-enabled apt-daily.service apt-daily.timer apt-daily-upgrade.service apt-daily-upgrade.timer unattended-upgrades.service` reports `masked` for all five
- [ ] 10 consecutive launches of a downstream consumer (e.g. openclaw) with `lifecycle_hook_name` set reach `InService` without `ABANDON`

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)